### PR TITLE
Fix quest description fallback issue

### DIFF
--- a/frontend/src/components/admin/QuestManagement.tsx
+++ b/frontend/src/components/admin/QuestManagement.tsx
@@ -186,7 +186,7 @@ const QuestManagement: React.FC<QuestManagementProps> = () => {
         setEditingQuest(quest);
         setFormData({
             title: quest.title,
-            description: quest.description,
+            description: quest.description || '',
             bounty: quest.bounty,
             isRepeatable: quest.isRepeatable,
             cooldownDays: quest.cooldownDays,


### PR DESCRIPTION
Add empty string fallback for `quest.description` to resolve React controlled component warnings.