### PR TITLE
refactor(quest-board): remove unused pagination state update

### DIFF
--- a/frontend/src/components/quest-board.tsx
+++ b/frontend/src/components/quest-board.tsx
@@ -837,7 +837,6 @@ const QuestBoard: React.FC = () => {
 
       // Update pagination state
       if (questData.pagination) {
-        setCurrentPage(questData.pagination.page)
         setTotalPages(questData.pagination.totalPages)
         setTotalQuests(questData.pagination.total)
       }


### PR DESCRIPTION
This will hopefully fix the "Next" button on quest pagination