### PR TITLE
fix(quest-board): rename pagination field

### DIFF
--- a/frontend/src/components/quest-board.tsx
+++ b/frontend/src/components/quest-board.tsx
@@ -831,9 +831,12 @@ const QuestBoard: React.FC = () => {
 
       // Update pagination state
       if (questData.pagination) {
-        // This is important to sync with server-side state, e.g., if requested page is out of bounds
-        if (questData.pagination.currentPage !== currentPage) {
-            setCurrentPage(questData.pagination.currentPage)
+        const serverPage =
+          questData.pagination.currentPage ?? questData.pagination.page
+
+        // Fallback for older backend responses where `currentPage` is absent
+        if (serverPage !== undefined && serverPage !== currentPage) {
+          setCurrentPage(serverPage)
         }
         setTotalPages(questData.pagination.totalPages)
         setTotalQuests(questData.pagination.total)

--- a/frontend/src/components/quest-board.tsx
+++ b/frontend/src/components/quest-board.tsx
@@ -832,8 +832,8 @@ const QuestBoard: React.FC = () => {
       // Update pagination state
       if (questData.pagination) {
         // This is important to sync with server-side state, e.g., if requested page is out of bounds
-        if (questData.pagination.page !== currentPage) {
-            setCurrentPage(questData.pagination.page)
+        if (questData.pagination.currentPage !== currentPage) {
+            setCurrentPage(questData.pagination.currentPage)
         }
         setTotalPages(questData.pagination.totalPages)
         setTotalQuests(questData.pagination.total)

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -116,7 +116,7 @@ export interface QuestListingResponse {
          * Current page index (1-based) returned by the backend.
          * Renamed from `page` to `currentPage` for clarity.
          */
-        currentPage: number;
+        currentPage?: number;
         /**
          * (Deprecated) Kept for backward compatibility with older responses.
          */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -112,7 +112,15 @@ export interface DashboardData {
 export interface QuestListingResponse {
     quests: Quest[];
     pagination: {
-        page: number;
+        /**
+         * Current page index (1-based) returned by the backend.
+         * Renamed from `page` to `currentPage` for clarity.
+         */
+        currentPage: number;
+        /**
+         * (Deprecated) Kept for backward compatibility with older responses.
+         */
+        page?: number;
         limit: number;
         total: number;
         totalPages: number;


### PR DESCRIPTION
This should stop the behaviour where the loaded page is reset to "undefined", snapping the view back to page 1, and preventing progressive viewing of the available quests.